### PR TITLE
Add Ruby 2.7.6 Docker image for deployment

### DIFF
--- a/ruby/2.7-stretch-node-awscli/Dockerfile
+++ b/ruby/2.7-stretch-node-awscli/Dockerfile
@@ -1,0 +1,17 @@
+FROM cimg/ruby:2.7.6-browsers
+
+# Add repository sources & transports
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
+  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list \
+  && sudo apt-get install apt-transport-https \
+  && sudo apt-get update
+
+# Add packages:
+RUN sudo apt-get install yarn python3-pip gettext-base \
+  && pip3 install awscli --upgrade --user
+
+# Set path for awscli
+ENV PATH "$PATH:~/.local/bin"
+
+# Update bundler
+RUN gem install bundler:2.3.15


### PR DESCRIPTION
This creates a 2.7.6 version of the Docker
image being used for the CircleCI deployment
process.

In the 2.6 version, the 2.6-stretch-node circleci
variant was used, but there is no equivalent in the
cimg repo (the new CircleCI repo). Since the same
image is being used for running the test suite as
for deploying, we are choosing to use the -browsers
variant here which has Node.js, Selenium, and browser
dependencies pre-installed.