### PR TITLE
Add CI and build versions for Ruby 3.0.4 and 3.1.2 for prosecco

### DIFF
--- a/ruby/2.7.6/Dockerfile
+++ b/ruby/2.7.6/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update -qq \
   gnupg \
   imagemagick \
   jest \
+  jq \
   libpq-dev \
   lsb-release \
   python2 \

--- a/ruby/3.0.4-alpine-node/Dockerfile
+++ b/ruby/3.0.4-alpine-node/Dockerfile
@@ -1,0 +1,14 @@
+FROM amd64/ruby:3.0.4-alpine
+
+RUN apk -v --update add \
+      build-base \
+      bash \
+      ruby-dev \
+      imagemagick6-dev \
+      imagemagick6 \
+      nodejs \
+      zlib-dev \
+      postgresql-dev \ 
+      tzdata \
+      git \
+    && rm /var/cache/apk/*

--- a/ruby/3.0.4/Dockerfile
+++ b/ruby/3.0.4/Dockerfile
@@ -1,0 +1,53 @@
+ARG BASE_IMAGE=amd64/ruby
+ARG BASE_TAG=3.0.4
+ARG BASE_IMAGE=${BASE_IMAGE}:${BASE_TAG}
+
+FROM ${BASE_IMAGE}
+
+RUN apt-get update -qq \
+  && apt-get install -y \
+  build-essential \
+  ca-certificates \
+  curl \
+  gettext-base \
+  git \
+  gnupg \
+  imagemagick \
+  jest \
+  jq \
+  libpq-dev \
+  lsb-release \
+  python2 \
+  python3-pip \
+  shared-mime-info \
+  zip \
+  && mkdir -p /etc/apt/keyrings \
+  && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+  && echo \
+  "deb [arch=$(dpkg --print-architecture) \
+  signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
+  && curl -sL https://deb.nodesource.com/setup_14.x | bash \
+  && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+  && echo "deb https://dl.yarnpkg.com/debian/ stable main" \
+  > /etc/apt/sources.list.d/yarn.list \
+  && apt-get update -qq \
+  && apt-get install -y \
+  docker-ce \
+  docker-ce-cli \
+  containerd.io \
+  nodejs \
+  yarn \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && pip3 install awscli --upgrade --user
+
+# Set path for awscli
+ENV PATH "$PATH:~/.local/bin"
+
+RUN gem install bundler:2.3.24
+
+ARG RAILS_ROOT=/app/
+WORKDIR $RAILS_ROOT
+
+COPY . .

--- a/ruby/3.1.2-alpine-node/Dockerfile
+++ b/ruby/3.1.2-alpine-node/Dockerfile
@@ -1,0 +1,14 @@
+FROM amd64/ruby:3.1.2-alpine
+
+RUN apk -v --update add \
+      build-base \
+      bash \
+      ruby-dev \
+      imagemagick6-dev \
+      imagemagick6 \
+      nodejs \
+      zlib-dev \
+      postgresql-dev \ 
+      tzdata \
+      git \
+    && rm /var/cache/apk/*

--- a/ruby/3.1.2/Dockerfile
+++ b/ruby/3.1.2/Dockerfile
@@ -1,0 +1,53 @@
+ARG BASE_IMAGE=amd64/ruby
+ARG BASE_TAG=3.1.2
+ARG BASE_IMAGE=${BASE_IMAGE}:${BASE_TAG}
+
+FROM ${BASE_IMAGE}
+
+RUN apt-get update -qq \
+  && apt-get install -y \
+  build-essential \
+  ca-certificates \
+  curl \
+  gettext-base \
+  git \
+  gnupg \
+  imagemagick \
+  jest \
+  jq \
+  libpq-dev \
+  lsb-release \
+  python2 \
+  python3-pip \
+  shared-mime-info \
+  zip \
+  && mkdir -p /etc/apt/keyrings \
+  && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+  && echo \
+  "deb [arch=$(dpkg --print-architecture) \
+  signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
+  && curl -sL https://deb.nodesource.com/setup_14.x | bash \
+  && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+  && echo "deb https://dl.yarnpkg.com/debian/ stable main" \
+  > /etc/apt/sources.list.d/yarn.list \
+  && apt-get update -qq \
+  && apt-get install -y \
+  docker-ce \
+  docker-ce-cli \
+  containerd.io \
+  nodejs \
+  yarn \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && pip3 install awscli --upgrade --user
+
+# Set path for awscli
+ENV PATH "$PATH:~/.local/bin"
+
+RUN gem install bundler:2.3.24
+
+ARG RAILS_ROOT=/app/
+WORKDIR $RAILS_ROOT
+
+COPY . .


### PR DESCRIPTION
This also adds `jq` to the 2.7.6 build version.