### PR TITLE
Add libxml2-dev and libxml2 to ruby:3.0.4-alpine

### DIFF
--- a/ruby/3.0.4-alpine-node/Dockerfile
+++ b/ruby/3.0.4-alpine-node/Dockerfile
@@ -6,9 +6,11 @@ RUN apk -v --update add \
       ruby-dev \
       imagemagick6-dev \
       imagemagick6 \
+      libxml2 \
+      libxml2-dev \
       nodejs \
       zlib-dev \
-      postgresql-dev \ 
+      postgresql-dev \
       tzdata \
       git \
     && rm /var/cache/apk/*


### PR DESCRIPTION
libxml2 is required by 'libxml-ruby' gem
