### PR TITLE
Change imagemagick version to latest

### DIFF
--- a/ruby/3.0.4-alpine-node/Dockerfile
+++ b/ruby/3.0.4-alpine-node/Dockerfile
@@ -4,8 +4,8 @@ RUN apk -v --update add \
       build-base \
       bash \
       ruby-dev \
-      imagemagick6-dev \
-      imagemagick6 \
+      imagemagick-dev \
+      imagemagick \
       libxml2 \
       libxml2-dev \
       nodejs \


### PR DESCRIPTION
This change allow us to use latest imagemagick version [available \(7\)](https://pkgs.alpinelinux.org/package/edge/community/aarch64/imagemagick) instead of version 6