### PR TITLE
Clone ruby 3.1.3 docker file but add mysql to use it on ramp

### DIFF
--- a/ruby/3.1.3-alpine-node-msql/Dockerfile
+++ b/ruby/3.1.3-alpine-node-msql/Dockerfile
@@ -1,0 +1,17 @@
+FROM amd64/ruby:3.1.3-alpine
+
+RUN apk -v --update add \
+      build-base \
+      bash \
+      ruby-dev \
+      imagemagick-dev \
+      imagemagick \
+      libxml2 \
+      libxml2-dev \
+      nodejs \
+      zlib-dev \
+      postgresql-dev \
+      mysql \
+      tzdata \
+      git \
+    && rm /var/cache/apk/*


### PR DESCRIPTION
I cloned it to avoid making changes to the 🐳  dockerfile prosecco uses (also, prosecco doesn't need mysql)